### PR TITLE
There was a mispelling on one of the commands

### DIFF
--- a/src/pages/practical/cp4apps/index.mdx
+++ b/src/pages/practical/cp4apps/index.mdx
@@ -246,7 +246,7 @@ Create a project or use an existing one. Set the OpenShift Container Platform CL
 
 - Verify project context
     ```bash
-    oc projet -q
+    oc project -q
     ```
 
 


### PR DESCRIPTION
currently we have `oc projet` as the command we should run. This is a type and it should instead be `oc project` 