### PR TITLE
Fix labels that don't process Globals

### DIFF
--- a/src/pages/getting-started/cli/index.mdx
+++ b/src/pages/getting-started/cli/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: <Globals name="shortName" /> CLI
+title: Cloud Native Toolkit CLI
 ---
 import Globals from 'gatsby-theme-carbon/src/templates/Globals';
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -37,7 +37,7 @@ export default HomepageTemplate;
 <Column colLg={4} colMd={4} noGutterMdLeft>
 <ArticleCard
     color="dark"
-    title="<Globals name=&quot;templates&quot; />"
+    title="Code Patterns"
     subTitle="Get some code to get you started"
     href="/codepatterns/overview"
     >


### PR DESCRIPTION
No issue, misc. problems Matt found.

Hardcode global values in labels on pages that don't substitute from the global values file.