### PR TITLE
Fixed Codewind install links.

### DIFF
--- a/src/pages/practical/cp4apps/index.mdx
+++ b/src/pages/practical/cp4apps/index.mdx
@@ -56,9 +56,9 @@ Set up the dev tools.
 
 Install Codewind and Appsody.
 
-- [Install Codewind for VS Code IDE](https://www.eclipse.org/codewind/mdt-vsc-installinfo.html)
+- [Install Codewind for VS Code IDE](https://www.eclipse.org/codewind/vsc-getting-started.html)
 
-- [Install Codewind for Eclipse IDE](https://www.eclipse.org/codewind/mdt-eclipse-installinfo.html)
+- [Install Codewind for Eclipse IDE](https://www.eclipse.org/codewind/eclipse-getting-started.html)
 
 - [Install the Appsody CLI](https://appsody.dev/docs/getting-started/installation)
 


### PR DESCRIPTION
Links went to 404; replaced with working links.
However, links in the "configure the codewind plugin" section are still broken, not sure what to replace them with.